### PR TITLE
Minor fix sox-audio: export the class to be extend allowed

### DIFF
--- a/webcomponents/sox-audio/sox-audio.js
+++ b/webcomponents/sox-audio/sox-audio.js
@@ -8,7 +8,7 @@ import {LibgtkIOStream} from 'gtkiostream/libgtkiostream-.js';
  * @polymer
  * @demo demo/index.html
  */
-class SoxAudio extends LibgtkIOStream {
+export class SoxAudio extends LibgtkIOStream {
   static get properties() {
     return {
       url: { // url for fetching the audio


### PR DESCRIPTION
We will extend this class on the client app to know once decodeURL succeed :

super.decodeURL().then(()=>{
  // do the next process on the client app
})