### PR TITLE
Fixes collision/prototype change with octave 5.x

### DIFF
--- a/README
+++ b/README
@@ -42,7 +42,7 @@ g++ `pkg-config --cflags gtk+-2.0` LabelsTest.C -o LabelsTest `pkg-config --libs
 For Unix/Linux etc. Users :
 
 Run the auto conf script :
-./scripts/myAutoreconf.sh
+./tools/autotools.sh
 
 Run configure  : ./configure --prefix=/usr/local
 Run make : make

--- a/configure.ac
+++ b/configure.ac
@@ -269,6 +269,7 @@ else
     MKOCTFILE_LIBS="$(echo \
       $(unset RLD_FLAG; $MKOCTFILE -p RLD_FLAG | $CAT) \
       $(unset LDFLAGS; $MKOCTFILE -p LDFLAGS | $CAT) \
+      -L$(unset OCTLIBDIR; $MKOCTFILE -p OCTLIBDIR | $CAT) \
       $(unset LIBOCTINTERP; $MKOCTFILE -p LIBOCTINTERP | $CAT) \
       $(unset LIBOCTAVE; $MKOCTFILE -p LIBOCTAVE | $CAT) \
       $(unset LIBCRUFT; $MKOCTFILE -p LIBCRUFT | $CAT) \

--- a/configure.ac
+++ b/configure.ac
@@ -233,23 +233,23 @@ if test "$MKOCTFILE" != "mkoctfile"; then
       # no mkoctfile program_invocation_name
 
     AC_ARG_WITH([octave-include-path],
-    [--with-octave-include-path location of the octave headers, defaults to /usr/include/octave-3.2.4],
+    [--with-octave-include-path location of the octave headers, defaults to -I/usr/include/octave-3.8.1],
     [MKOCTFILE_CFLAGS="-I$withval"],
     [MKOCTFILE_CFLAGS='-I/usr/include/octave-3.8.1'])
     AC_ARG_WITH([octave-lib-path],
-      [--with-octave-lib-path location of the octave libraries, defaults to -L/usr/lib/octave-3.2.4],
+      [--with-octave-lib-path location of the octave libraries, defaults to -L/usr/lib/octave-3.8.1],
       [MKOCTFILE_LIBPATH="$withval"],
       [MKOCTFILE_LIBPATH='-L/usr/lib/octave-3.8.1'])
     AC_SUBST([MKOCTFILE_LIBPATH])
 
     AC_ARG_WITH([octave-lib-pc-path],
-      [--with-octave-lib-pc-path location of the octave libraries for the .pc, defaults to -L/usr/lib/octave-3.2.4],
+      [--with-octave-lib-pc-path location of the octave libraries for the .pc, defaults to -L/usr/lib/octave-3.8.1],
       [MKOCTFILE_PCLIBPATH="$withval"],
       [MKOCTFILE_PCLIBPATH='-L/usr/lib/octave-3.8.1'])
     AC_SUBST([MKOCTFILE_PCLIBPATH])
 
     AC_ARG_WITH([octave-libs],
-      [--with-octave-libs location of the octave libraries, defaults to '-lcruft -loctave -loctinterp'],
+      [--with-octave-libs location of the octave libraries, defaults to '-loctave -loctinterp'],
       [MKOCTFILE_LIBS="$withval"],
       [MKOCTFILE_LIBS='-loctave -loctinterp'])
 

--- a/configure.ac
+++ b/configure.ac
@@ -268,7 +268,7 @@ else
     MKOCTFILE_CFLAGS="$(echo $($MKOCTFILE -p INCFLAGS | $CAT) | sed -re 's|\\|/|g')"
     MKOCTFILE_LIBS="$(echo \
       $(unset RLD_FLAG; $MKOCTFILE -p RLD_FLAG | $CAT) \
-      $(unset LFLAGS; $MKOCTFILE -p LFLAGS | $CAT) \
+      $(unset LDFLAGS; $MKOCTFILE -p LDFLAGS | $CAT) \
       $(unset LIBOCTINTERP; $MKOCTFILE -p LIBOCTINTERP | $CAT) \
       $(unset LIBOCTAVE; $MKOCTFILE -p LIBOCTAVE | $CAT) \
       $(unset LIBCRUFT; $MKOCTFILE -p LIBCRUFT | $CAT) \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,6 +53,8 @@ if HAVE_SOX
 libgtkIOStream_la_SOURCES += Sox.C
 libgtkIOStream_la_CPPFLAGS += $(SOX_CFLAGS)
 libgtkIOStream_la_LDFLAGS += $(SOX_LIBS)
+libdsp_la_CPPFLAGS += $(SOX_CFLAGS)
+libdsp_la_LDFLAGS += $(SOX_LIBS)
 endif
 
 if HAVE_OCTAVE

--- a/src/Octave.C
+++ b/src/Octave.C
@@ -43,7 +43,6 @@ extern OCTINTERP_API void clean_up_and_exit (int, bool);
 //extern void clean_up_and_exit (int retval);
 
 extern void set_global_value (const string& nm, const octave_value& val);
-extern octave_value get_global_value (const string& nm, bool silent = false);
 
 // extern OCTINTERP_API bool octave_initialized;
 extern OCTINTERP_API bool octave_interpreter_ready;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -103,10 +103,12 @@ endif
 if HAVE_SOX
 if HAVE_EMSCRIPTEN
 noinst_PROGRAMS += SoxTest2
+EXTRA_CFLAGS += $(SOX_CFLAGS)
 EXTRA_LIBS += $(SOX_LIBS)
 else
 if NOT_MINGW_SYSTEM
 noinst_PROGRAMS += IIOMMapTest IIOTest IIOQueueTest SoxTest SoxTest2
+EXTRA_CFLAGS += $(SOX_CFLAGS)
 EXTRA_LIBS += $(SOX_LIBS)
 endif
 endif


### PR DESCRIPTION
"octave_value get_global_value ()" is declared in Octave headers, there is no need to repeat it as extern.

The actual error message is as below:

```
Octave.C:46:21: error: default argument given for parameter 2 of ‘octave_value get_global_value(const string&, bool)’ [-fpermissive]
   46 | extern octave_value get_global_value (const string& nm, bool silent = false);
      |                     ^~~~~~~~~~~~~~~~
In file included from /usr/include/octave-5.1.0/octave/../octave/hook-fcn.h:33,
                 from /usr/include/octave-5.1.0/octave/../octave/input.h:34,
                 from /usr/include/octave-5.1.0/octave/../octave/lex.h:34,
                 from /usr/include/octave-5.1.0/octave/../octave/parse.h:36,
                 from Octave.C:18:
/usr/include/octave-5.1.0/octave/../octave/variables.h:144:1: note: previous specification in ‘octave_value get_global_value(const string&, bool)’ here
  144 | get_global_value (const std::string& nm, bool silent = false);
      | ^~~~~~~~~~~~~~~~
```

Fixes https://github.com/flatmax/gtkiostream/issues/4