### PR TITLE
Debugging on safari

### DIFF
--- a/webcomponents/gtkiostream/libgtkiostream.js
+++ b/webcomponents/gtkiostream/libgtkiostream.js
@@ -17,10 +17,6 @@ export class LibgtkIOStream extends LitElement {
 
   constructor() {
     super();
-    this.libgtkIOStream = {};
-  }
-
-  firstUpdated() {
     modProm().then((mod)=>{
       this.libgtkIOStream = mod; // for rendered wasm that delay
       this.WASMReady();

--- a/webcomponents/sox-audio/sox-audio.js
+++ b/webcomponents/sox-audio/sox-audio.js
@@ -29,6 +29,21 @@ export class SoxAudio extends LibgtkIOStream {
     super();
     // Sox has troubles reading from memory files with accurate length and channel numbers
     this.frames=5000000; // the default number to read in
+
+    // patch for safari: Blob.arrayBuffer is not a function
+    File.prototype.arrayBuffer = File.prototype.arrayBuffer || this.getArrayBuffer;
+    Blob.prototype.arrayBuffer = Blob.prototype.arrayBuffer || this.getArrayBuffer;
+  }
+
+  getArrayBuffer() {
+    // this: File or Blob
+    return new Promise((resolve) => {
+      let fr = new FileReader();
+      fr.onload = () => {
+        resolve(fr.result);
+      };
+      fr.readAsArrayBuffer(this);
+    })
   }
 
   /** Observed properties are handled here.


### PR DESCRIPTION
On the list models, click the model item should be plotting the data. But safari shows the bug: blob.arrayBuffer is not a function.

Follow this link to resolve it: https://gist.github.com/hanayashiki/8dac237671343e7f0b15de617b0051bd