### PR TITLE
Minor fixed lib name

### DIFF
--- a/webcomponents/dsp/DSP.js
+++ b/webcomponents/dsp/DSP.js
@@ -26,7 +26,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { html, css, LitElement } from 'lit-element';
+import { LitElement } from 'lit';
 import modProm from './libdsp.js';
 
 export class DSP extends LitElement {

--- a/webcomponents/dsp/package.json
+++ b/webcomponents/dsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libdsp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The gtkiostream dsp for nodejs and the browser",
   "main": "DSP.js",
   "author": "flatmax",

--- a/webcomponents/fir/demo/demo-example.js
+++ b/webcomponents/fir/demo/demo-example.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-element';
+import { html } from 'lit';
 import { FIR } from '../fir-';
 
 /** Example demo element for testing element loading

--- a/webcomponents/fir/package.json
+++ b/webcomponents/fir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fir-dsp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "WASM Webcomponent fir- for digital signal processing FIR convolution following open-wc recommendations",
   "author": "flatmax",
   "license": "MIT",
@@ -12,9 +12,8 @@
     "storybook:build": "build-storybook"
   },
   "dependencies": {
-    "libdsp": "1.0.1",
-    "lit-element": "^2.5.1",
-    "lit-html": "^1.4.1"
+    "libdsp": "1.0.2",
+    "lit": "^2.0.2"
   },
   "devDependencies": {
     "@web/dev-server": "^0.1.18",

--- a/webcomponents/gtkiostream/libgtkiostream.js
+++ b/webcomponents/gtkiostream/libgtkiostream.js
@@ -26,7 +26,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { LitElement } from 'lit-element';
+import { LitElement } from 'lit';
 import modProm from './libgtkIOStream.js';
 
 /**

--- a/webcomponents/gtkiostream/package.json
+++ b/webcomponents/gtkiostream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtkiostream",
-  "version": "1.9.16",
+  "version": "1.9.17",
   "description": "The gtkiostream WASM modules for nodejs and the browser",
   "main": "libgtkIOStreamNode.js",
   "scripts": {

--- a/webcomponents/sox-audio/demo/demo-example.js
+++ b/webcomponents/sox-audio/demo/demo-example.js
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit-element';
+import { LitElement, html } from 'lit';
 import '../sox-audio';
 
 /** Example demo element for testing element loading

--- a/webcomponents/sox-audio/demo/multiple-sox.js
+++ b/webcomponents/sox-audio/demo/multiple-sox.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-element';
+import { html } from 'lit';
 import {SoxAudio } from '../sox-audio';
 import './parent-element';
 

--- a/webcomponents/sox-audio/demo/parent-element.js
+++ b/webcomponents/sox-audio/demo/parent-element.js
@@ -1,4 +1,4 @@
-import { html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
 import './sox-item';
 
 class ParentElement extends LitElement {

--- a/webcomponents/sox-audio/demo/sox-item.js
+++ b/webcomponents/sox-audio/demo/sox-item.js
@@ -1,4 +1,3 @@
-import { html } from 'lit-element';
 import { SoxAudio } from '../sox-audio';
 
 class SoxItem extends SoxAudio {

--- a/webcomponents/sox-audio/package.json
+++ b/webcomponents/sox-audio/package.json
@@ -1,10 +1,10 @@
 {
   "name": "sox-element",
-  "version": "1.9.16",
+  "version": "1.9.17",
   "description": "The gtkiostream sox class as a webcompoenent",
   "main": "sox-audio.js",
   "dependencies": {
-    "gtkiostream": "^1.9.16"
+    "gtkiostream": "^1.9.17"
   },
   "devDependencies": {
     "@webcomponents/webcomponentsjs": "^2.4.3"


### PR DESCRIPTION
Latest lit source is lit instead of lit-element

```
import { html, css, LitElement, etc } from 'lit'
```