### PR TITLE
configure.ac: add option to disable tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,12 @@ AUTOMAKE_OPTIONS = foreign subdir-objects
 SUBDIRS = src api include
 
 if !HAVE_EMSCRIPTEN
-SUBDIRS += applications test
+SUBDIRS += applications
+
+if HAVE_TESTS
+SUBDIRS += test
+endif
+
 endif
 
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,11 @@ fi
 # Checks for documentation
 AM_CONDITIONAL([HAVE_DOXYGEN],[test -n "$DOXYGEN"])AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([api/Doxyfile])])
 
+AC_ARG_ENABLE(tests, AS_HELP_STRING([--disable-tests],
+	      [Disable tests (default: enabled)]),
+	      [TESTS=$enableval], [TESTS=yes])
+AM_CONDITIONAL([HAVE_TESTS],[test "x$TESTS" = xyes])
+
 #check whether this is a cygwin system
 AM_CONDITIONAL(CYGWIN, test "$build_os" = "cygwin")
 


### PR DESCRIPTION
This commit adds an option that allows to disable building tests, which are not useful in some situations.